### PR TITLE
Preserve all EXR subimages by default

### DIFF
--- a/Convert-SBS-Interactive.ps1
+++ b/Convert-SBS-Interactive.ps1
@@ -15,6 +15,7 @@ param(
   [string]$DataType = "float",
   [switch]$Recurse,        # include subfolders
   [switch]$InPlace,        # overwrite originals (writes temp, then swaps)
+    [switch]$FirstSubimage,  # legacy: only subimage 0
   [switch]$Quiet           # less console chatter
 )
 
@@ -115,7 +116,7 @@ for ($s=0; $s -lt $totShots; $s++) {
     Write-Progress -Id 2 -ParentId 1 -Activity "Converting frames" -Status "$($i+1)/$total  $($f.Name)" -PercentComplete $filePct
 
     # Build args and run
-    $args = @($src,'--subimage','0','--fullpixels','-d',$DataType) + $compArgs + @('-o',$dst)
+    $args = @($src) + (if ($FirstSubimage) { @('--subimage','0') } else { @('-a') }) + @('--fullpixels','-d',$DataType) + $compArgs + @('-o',$dst)
     & $OiiotoolPath @args
     if ($LASTEXITCODE -eq 0) {
       if ($InPlace) {

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ Unreal’s \*\*Panoramic Render Pass\*\* can output stereoscopic panoramas where
 
 \* Reads your EXR frames and writes a \*\*fixed\*\* EXR where `displayWindow == dataWindow` using `--fullpixels`.
 
-\* Copies \*\*subimage 0\*\* (the main “FinalImage”) and outputs a single SBS frame per input.
+\* Copies \*\*all subimages\*\* (depth, lighting, etc.) by default. Use `-FirstSubimage` to keep only the first pass.
 
 \* Writes results into \*\*sibling\*\* folders named `<Shot>\_SBS`, mirroring any subfolders.
 
@@ -250,7 +250,7 @@ Get-ChildItem -LiteralPath $in -Filter \*.exr | ForEach-Object {
 
 &nbsp; $dst = Join-Path $out ($\_.BaseName + "\_SBS.exr")
 
-&nbsp; \& $oiio $\_.FullName --subimage 0 --fullpixels -d float --compression dwab:45 -o $dst
+&nbsp; \& $oiio $\_.FullName -a --fullpixels -d float --compression dwab:45 -o $dst
 
 &nbsp; if ($LASTEXITCODE -ne 0) { Write-Warning "FAILED -> $($\_.FullName)" }
 
@@ -268,7 +268,7 @@ Get-ChildItem -LiteralPath $in -Filter \*.exr | ForEach-Object {
 
 
 
-\* Output EXR: \*\*single subimage\*\*, SBS visible everywhere
+\* Output EXR: \*\*all subimages retained\*\*, SBS visible everywhere
 
 \* The file name: `<OriginalBase>\_SBS.exr`
 
@@ -280,7 +280,7 @@ Get-ChildItem -LiteralPath $in -Filter \*.exr | ForEach-Object {
 
 
 
-\*\*Note:\*\* We intentionally only copy \*\*subimage 0\*\* (“FinalImage”). Additional parts/passes (e.g., depth, detail lighting) are not preserved in the fixed SBS outputs — by design for editorial review/dailies. If you need other parts, we can add a switch to include them.
+\*\*Note:\*\* By default all subimages (e.g., depth, detail lighting) are preserved. Use `-FirstSubimage` for legacy single-pass output.
 
 
 
@@ -388,7 +388,7 @@ A: Not safely/portably. EXR’s full/data windows affect image layout. We fix it
 
 \*\*Q: Can I preserve all subimages (depth, lighting, etc.)?\*\*
 
-A: This tool targets editorial SBS. We currently extract \*\*subimage 0\*\*. We can extend the script to copy specific subimages or re-emit a multi-part file if you need that.
+A: Yes, all subimages are preserved. Use `-FirstSubimage` to emit only the first pass if needed.
 
 
 


### PR DESCRIPTION
## Summary
- Remove the hardcoded `--subimage 0` and run `oiiotool` with `-a` so all EXR subimages are processed.
- Add a `-FirstSubimage` switch to keep only the first pass for legacy single-image output.
- Document the new default behaviour and optional flag in the README.

## Testing
- `pwsh -File Convert-SBS-Interactive.ps1 -InputDirs .` *(fails: command not found)*
- `oiiotool --info multi.exr` *(2 subimages)*
- `oiiotool --info out_multi.exr` *(2 subimages)*
- `oiiotool --info out_sub0.exr` *(single subimage)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5dc539cc8325aebf2997ac1cd884