### PR TITLE
Parallelize frame conversion

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -111,6 +111,7 @@ The tool needs these programs to work:
    - Click "Convert Selected"
    - Watch the progress bars
    - Wait for "All conversions complete" message
+   - The tool processes multiple frames in parallel, using all available CPU cores
 
 6. **Find Your Results**
    - Look for new folders named `[YourShotName]_SBS`


### PR DESCRIPTION
## Summary
- convert frames concurrently with a `ThreadPoolExecutor` for faster processing
- document parallel CPU usage during conversion

## Testing
- `python -m py_compile sbs_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdd54abe2883258faee40508fcfe12